### PR TITLE
Some fine tuning of paren spacing

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -18,6 +18,7 @@ const argv = minimist(process.argv.slice(2), {
     "semi",
     "single-quote",
     "bracket-spacing",
+    "calypso-spacing",
     "jsx-bracket-same-line",
     // The supports-color package (a sub sub dependency) looks directly at
     // `process.argv` for `--no-color` and such-like options. The reason it is
@@ -126,6 +127,7 @@ const options = {
   printWidth: getIntOption("print-width"),
   tabWidth: getIntOption("tab-width"),
   bracketSpacing: argv["bracket-spacing"],
+  calypsoSpacing: argv["calypso-spacing"],
   singleQuote: argv["single-quote"],
   jsxBracketSameLine: argv["jsx-bracket-same-line"],
   trailingComma: getTrailingComma(),
@@ -190,6 +192,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
       "  --no-semi                Do not print semicolons, except at the beginning of lines which may need them. Defaults to false.\n" +
       "  --single-quote           Use single quotes instead of double.\n" +
       "  --bracket-spacing        Put spaces between brackets. Defaults to true.\n" +
+      "  --calypso-spacing        Put spaces between parens, Calypso style.\n" +
       "  --jsx-bracket-same-line  Put > on the last line. Defaults to false.\n" +
       "  --trailing-comma <none|es5|all>\n" +
       "                           Print trailing commas wherever possible. Defaults to none.\n" +

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,6 +92,7 @@
     <label><input type="checkbox" id="semi" checked></input> semi</label>
     <label><input type="checkbox" id="singleQuote"></input> singleQuote</label>
     <label><input type="checkbox" id="bracketSpacing" checked></input> bracketSpacing</label>
+    <label><input type="checkbox" id="calypsoSpacing"></input> calypsoSpacing</label>
     <label><input type="checkbox" id="jsxBracketSameLine"></input> jsxBracketSameLine</label>
     <label>trailingComma <select id="trailingComma"><option value="none">none</option><option value="es5">es5</option><option value="all">all</option></select></label>
     <label>parser <select id="parser"><option value="babylon">babylon</option><option value="flow">flow</option></select></label>
@@ -113,7 +114,7 @@
 </div>
 
 <script id="code">
-var OPTIONS = ['printWidth', 'tabWidth', 'singleQuote', 'trailingComma', 'bracketSpacing', 'jsxBracketSameLine', 'parser', 'semi', 'useTabs', 'doc'];
+var OPTIONS = ['printWidth', 'tabWidth', 'singleQuote', 'trailingComma', 'bracketSpacing', 'calypsoSpacing', 'jsxBracketSameLine', 'parser', 'semi', 'useTabs', 'doc'];
 function setOptions(options) {
   OPTIONS.forEach(function(option) {
     var elem = document.getElementById(option);

--- a/docs/prettier.min.js
+++ b/docs/prettier.min.js
@@ -19,7 +19,7 @@ Object.defineProperty(exports, "__esModule", {
 
 // This regex comes from regex.coffee, and is inserted here by generate-index.js
 // (run `npm run build`).
-exports.default = /((['"])(?:(?!\2|\\).|\\(?:\r\n|[\s\S]))*(\2)?|`(?:[^`\\$]|\\[\s\S]|\$(?!\{)|\$\{(?:[^{}]|\{[^}]*\}?)*\}?)*(`)?)|(\/\/.*)|(\/\*(?:[^*]|\*(?!\/))*(\*\/)?)|(\/(?!\*)(?:\[(?:(?![\]\\]).|\\.)*\]|(?![\/\]\\]).|\\.)+\/(?:(?!\s*(?:\b|[\u0080-\uFFFF$\\'"~({]|[+\-!](?!=)|\.?\d))|[gmiyu]{1,5}\b(?![\u0080-\uFFFF$\\]|\s*(?:[+\-*%&|^<>!=?({]|\/(?![\/*])))))|(0[xX][\da-fA-F]+|0[oO][0-7]+|0[bB][01]+|(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?)|((?!\d)(?:(?!\s)[$\w\u0080-\uFFFF]|\\u[\da-fA-F]{4}|\\u\{[\da-fA-F]{1,6}\})+)|(--|\+\+|&&|\|\||=>|\.{3}|(?:[+\-\/%&|^]|\*{1,2}|<{1,2}|>{1,3}|!=?|={1,2})=?|[?~.,:;[\](){}])|(\s+)|(^$|[\s\S])/g;
+exports.default = /((['"])(?:(?!\2|\\).|\\(?:\r\n|[\s\S]))*(\2)?|`(?:[^`\\$]|\\[\s\S]|\$(?!\{)|\$\{(?:[^{}]|\{[^}]*\}?)*\}?)*(`)?)|(\/\/.*)|(\/\*(?:[^*]|\*(?!\/))*(\*\/)?)|(\/(?!\*)(?:\[(?:(?![\]\\]).|\\.)*\]|(?![\/\]\\]).|\\.)+\/(?:(?!\s*(?:\b|[\u0080-\uFFFF$\\'"~({]|[+\-!](?!=)|\.?\d))|[gmiyu]{1,5}\b(?![\u0080-\uFFFF$\\]|\s*(?:[+\-*%&|^<>!=?({]|\/(?![\/*])))))|(0[xX][\da-fA-F]+|0[oO][0-7]+|0[bB][01]+|(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?)|((?!\d)(?:(?!\s)[$\w\u0080-\uFFFF]|\\u[\da-fA-F]{4}|\\u\{[\da-fA-F]+\})+)|(--|\+\+|&&|\|\||=>|\.{3}|(?:[+\-\/%&|^]|\*{1,2}|<{1,2}|>{1,3}|!=?|={1,2})=?|[?~.,:;[\](){}])|(\s+)|(^$|[\s\S])/g;
 
 exports.matchToToken = function(match) {
   var token = {type: "invalid", value: match[0]};
@@ -830,7 +830,7 @@ Object.defineProperty(module, 'exports', {
 });
 
 var index$14 = function () {
-	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]/g;
 };
 
 var ansiRegex = index$14();
@@ -8660,6 +8660,7 @@ function group(contents, opts) {
     type: "group",
     contents: contents,
     break: !!opts.shouldBreak,
+    addedLine: !!opts.addedLine,
     expandedStates: opts.expandedStates
   };
 }
@@ -9946,11 +9947,11 @@ function printComments(path, print, options, needsSemi) {
 var comments$1 = { attach, printComments, printDanglingComments };
 
 var name = "prettier";
-var version$2 = "1.1.0";
-var description = "Prettier is an opinionated JavaScript formatter";
+var version$2 = "1.1.7";
+var description = "A fork of prettier to conform with wp-calypso styleguide";
 var bin = {"prettier":"./bin/prettier.js"};
-var repository = "prettier/prettier";
-var author = "James Long";
+var repository = "https://github.com/samouri/prettier";
+var author = "Samouri";
 var license = "MIT";
 var main$2 = "./index.js";
 var dependencies = {"ast-types":"0.9.8","babel-code-frame":"6.22.0","babylon":"7.0.0-beta.8","chalk":"1.1.3","esutils":"2.0.2","flow-parser":"0.43.0","get-stdin":"5.0.1","glob":"7.1.1","jest-validate":"19.0.0","minimist":"1.2.0"};
@@ -10650,6 +10651,7 @@ function genericPrint(path, options, printPath, args) {
   var node = path.getValue();
   var parts = [];
   var needsParens = false;
+  const calypsoSpace = options.calypsoSpacing ? " " : "";
   var linesWithoutParens = genericPrintNoParens(path, options, printPath, args);
 
   if (!node || isEmpty$1(linesWithoutParens)) {
@@ -10709,13 +10711,13 @@ function genericPrint(path, options, printPath, args) {
   }
 
   if (needsParens) {
-    parts.unshift("(");
+    parts.unshift("(", calypsoSpace);
   }
 
   parts.push(linesWithoutParens);
 
   if (needsParens) {
-    parts.push(")");
+    parts.push(calypsoSpace, ")");
   }
 
   return concat$2(parts);
@@ -10724,6 +10726,8 @@ function genericPrint(path, options, printPath, args) {
 function genericPrintNoParens(path, options, print, args) {
   var n = path.getValue();
   const semi = options.semi ? ";" : "";
+  const calypsoSpace = options.calypsoSpacing ? " " : "";
+  const calypsoLine = options.calypsoSpacing ? line$1 : softline$1;
 
   if (!n) {
     return "";
@@ -10777,7 +10781,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "ExpressionStatement":
       return concat$2([path.call(print, "expression"), semi]); // Babel extension.
     case "ParenthesizedExpression":
-      return concat$2(["(", path.call(print, "expression"), ")"]);
+      return concat$2(["(", calypsoSpace, path.call(print, "expression"), calypsoSpace, ")"]);
     case "AssignmentExpression":
       return printAssignment(
         n.left,
@@ -10944,9 +10948,12 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       // if the arrow function is expanded as last argument, we are adding a
-      // level of indentation and need to add a softline to align the closing )
+      // level of indentation and need to add a (soft) line to align the closing )
       // with the opening (.
-      const shouldAddSoftLine = args && args.expandLastArg;
+      // This means that the (soft) line is sometimes added, sometimes not. Add this fact as
+      // an `addedLine`opt to the returned `group`. It will be used by code that takes care
+      // of adding a space before the closing paren when the `calypso-spacing` option is on.
+      const shouldAddLine = args && args.expandLastArg;
 
       return group$1(
         concat$2([
@@ -10954,15 +10961,16 @@ function genericPrintNoParens(path, options, print, args) {
           group$1(
             concat$2([
               indent$2(concat$2([line$1, body])),
-              shouldAddSoftLine
+              shouldAddLine
                 ? concat$2([
                     ifBreak$1(shouldPrintComma(options, "all") ? "," : ""),
-                    softline$1
+                    calypsoLine
                   ])
                 : ""
             ])
           )
-        ])
+        ]),
+        { addedLine: shouldAddLine }
       );
     }
     case "MethodDefinition":
@@ -11256,7 +11264,7 @@ function genericPrintNoParens(path, options, print, args) {
         return concat$2([
           path.call(print, "callee"),
           path.call(print, "typeParameters"),
-          concat$2(["(", join$2(", ", path.map(print, "arguments")), ")"])
+          concat$2([ "(", calypsoSpace, join$2(", ", path.map(print, "arguments")), calypsoSpace, ")" ])
         ]);
       }
 
@@ -11382,7 +11390,7 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push(path.call(print, "value"));
       } else {
         if (n.computed) {
-          parts.push("[", path.call(print, "key"), "]");
+          parts.push("[", calypsoSpace, path.call(print, "key"), calypsoSpace, "]");
         } else {
           parts.push(printPropertyKey(path, options, print));
         }
@@ -11439,7 +11447,7 @@ function genericPrintNoParens(path, options, print, args) {
               "[",
               indent$2(
                 concat$2([
-                  softline$1,
+                  calypsoLine,
                   printArrayItems(path, options, "elements", print)
                 ])
               ),
@@ -11456,7 +11464,7 @@ function genericPrintNoParens(path, options, print, args) {
                 options,
                 /* sameIndent */ true
               ),
-              softline$1,
+              calypsoLine,
               "]"
             ])
           )
@@ -11503,7 +11511,18 @@ function genericPrintNoParens(path, options, print, args) {
     case "UnaryExpression":
       parts.push(n.operator);
 
-      if (/[a-z]$/.test(n.operator)) parts.push(" ");
+      if (
+        /[a-z]$/.test(n.operator) ||
+        (options.calypsoSpacing &&
+          n.operator === "!" &&
+          !(
+            n.argument &&
+            n.argument.type === "UnaryExpression" &&
+            n.argument.operator === "!"
+          ))
+      ) {
+        parts.push(" ");
+      }
 
       parts.push(path.call(print, "argument"));
 
@@ -11585,7 +11604,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "WithStatement":
       return concat$2([
         "with (",
+        calypsoSpace,
         path.call(print, "object"),
+        calypsoSpace,
         ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
@@ -11596,8 +11617,8 @@ function genericPrintNoParens(path, options, print, args) {
           "if (",
           group$1(
             concat$2([
-              indent$2(concat$2([softline$1, path.call(print, "test")])),
-              softline$1
+              indent$2(concat$2([calypsoLine, path.call(print, "test")])),
+              calypsoLine
             ])
           ),
           ")",
@@ -11650,7 +11671,7 @@ function genericPrintNoParens(path, options, print, args) {
           concat$2([
             indent$2(
               concat$2([
-                softline$1,
+                calypsoLine,
                 path.call(print, "init"),
                 ";",
                 line$1,
@@ -11660,7 +11681,7 @@ function genericPrintNoParens(path, options, print, args) {
                 path.call(print, "update")
               ])
             ),
-            softline$1
+            calypsoLine
           ])
         ),
         ")",
@@ -11672,8 +11693,8 @@ function genericPrintNoParens(path, options, print, args) {
         "while (",
         group$1(
           concat$2([
-            indent$2(concat$2([softline$1, path.call(print, "test")])),
-            softline$1
+            indent$2(concat$2([calypsoLine, path.call(print, "test")])),
+            calypsoLine
           ])
         ),
         ")",
@@ -11683,9 +11704,11 @@ function genericPrintNoParens(path, options, print, args) {
       // Note: esprima can't actually parse "for each (".
       return concat$2([
         n.each ? "for each (" : "for (",
+        calypsoSpace,
         path.call(print, "left"),
         " in ",
         path.call(print, "right"),
+        calypsoSpace,
         ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
@@ -11701,9 +11724,11 @@ function genericPrintNoParens(path, options, print, args) {
         "for",
         isAwait ? " await" : "",
         " (",
+        calypsoSpace,
         path.call(print, "left"),
         " of ",
         path.call(print, "right"),
+        calypsoSpace,
         ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
@@ -11720,7 +11745,7 @@ function genericPrintNoParens(path, options, print, args) {
       }
       parts.push("while");
 
-      parts.push(" (", path.call(print, "test"), ")", semi);
+      parts.push(" (", calypsoSpace, path.call(print, "test"), calypsoSpace, ")", semi);
 
       return concat$2(parts);
     case "DoExpression":
@@ -11768,13 +11793,13 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat$2(parts);
     case "CatchClause":
-      parts.push("catch (", path.call(print, "param"));
+      parts.push("catch (", calypsoSpace, path.call(print, "param"));
 
       if (n.guard)
         // Note: esprima does not recognize conditional catch clauses.
         parts.push(" if ", path.call(print, "guard"));
 
-      parts.push(") ", path.call(print, "body"));
+      parts.push(calypsoSpace, ") ", path.call(print, "body"));
 
       return concat$2(parts);
     case "ThrowStatement":
@@ -11783,7 +11808,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "SwitchStatement":
       return concat$2([
         "switch (",
+        calypsoSpace,
         path.call(print, "discriminant"),
+        calypsoSpace,
         ") {",
         n.cases.length > 0
           ? indent$2(concat$2([hardline$2, join$2(hardline$2, path.map(print, "cases"))]))
@@ -11866,7 +11893,7 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "property")
       ]);
     case "JSXSpreadAttribute":
-      return concat$2(["{...", path.call(print, "argument"), "}"]);
+      return concat$2(["{", calypsoSpace, "...", path.call(print, "argument"), calypsoSpace, "}"]);
     case "JSXExpressionContainer": {
       const parent = path.getParentNode(0);
 
@@ -11885,15 +11912,15 @@ function genericPrintNoParens(path, options, print, args) {
 
       if (shouldInline) {
         return group$1(
-          concat$2(["{", path.call(print, "expression"), lineSuffixBoundary$1, "}"])
+          concat$2(["{", calypsoSpace, path.call(print, "expression"), lineSuffixBoundary$1, calypsoSpace, "}"])
         );
       }
 
       return group$1(
         concat$2([
           "{",
-          indent$2(concat$2([softline$1, path.call(print, "expression")])),
-          softline$1,
+          indent$2(concat$2([calypsoLine, path.call(print, "expression")])),
+          calypsoLine,
           lineSuffixBoundary$1,
           "}"
         ])
@@ -12055,8 +12082,10 @@ function genericPrintNoParens(path, options, print, args) {
         if (i < expressions.length) {
           parts.push(
             "${",
+            calypsoSpace,
             removeLines(expressions[i]),
             lineSuffixBoundary$1,
+            calypsoSpace,
             "}"
           );
         }
@@ -12751,7 +12780,23 @@ function shouldGroupFirstArg(args) {
   );
 }
 
+function hasAddedLine(arg) {
+  switch (arg.type) {
+    case 'concat':
+      if (arg.parts.length > 0) {
+        return hasAddedLine(arg.parts[arg.parts.length - 1]);
+      }
+      return false;
+    case 'group':
+      return arg.addedLine;
+    default:
+      return false;
+  }
+}
+
 function printArgumentsList(path, options, print) {
+  const calypsoSpace = options.calypsoSpacing ? " " : "";
+  const calypsoLine = options.calypsoSpacing ? line$1 : softline$1;
   var printed = path.map(print, "arguments");
 
   if (printed.length === 0) {
@@ -12775,6 +12820,7 @@ function printArgumentsList(path, options, print) {
 
     // We want to print the last argument with a special flag
     let printedExpanded;
+    let lastArgAddedLine = false;
     let i = 0;
     path.each(function(argPath) {
       if (shouldGroupFirst && i === 0) {
@@ -12783,9 +12829,11 @@ function printArgumentsList(path, options, print) {
             .concat(printed.slice(1));
       }
       if (shouldGroupLast && i === args.length - 1) {
+        const printedLastArg = argPath.call(p => print(p, { expandLastArg: true }));
+        lastArgAddedLine = hasAddedLine(printedLastArg);
         printedExpanded = printed
           .slice(0, -1)
-          .concat(argPath.call(p => print(p, { expandLastArg: true })));
+          .concat(printedLastArg);
       }
       i++;
     }, "arguments");
@@ -12794,22 +12842,32 @@ function printArgumentsList(path, options, print) {
       printed.some(willBreak$2) ? breakParent$2 : "",
       conditionalGroup$1(
         [
-          concat$2(["(", join$2(concat$2([", "]), printedExpanded), ")"]),
+          concat$2([
+            "(",
+            calypsoSpace,
+            join$2(concat$2([", "]), printedExpanded),
+            lastArgAddedLine ? "" : calypsoSpace,
+            ")"
+          ]),
           shouldGroupFirst
             ? concat$2([
                 "(",
+                calypsoSpace,
                 group$1(printedExpanded[0], { shouldBreak: true }),
                 printed.length > 1 ? ", " : "",
                 join$2(concat$2([",", line$1]), printed.slice(1)),
+                calypsoSpace,
                 ")"
               ])
             : concat$2([
                 "(",
+                calypsoSpace,
                 join$2(concat$2([",", line$1]), printed.slice(0, -1)),
                 printed.length > 1 ? ", " : "",
                 group$1(util$4.getLast(printedExpanded), {
                   shouldBreak: true
                 }),
+                lastArgAddedLine ? "" : calypsoSpace,
                 ")"
               ]),
           group$1(
@@ -12817,7 +12875,7 @@ function printArgumentsList(path, options, print) {
               "(",
               indent$2(concat$2([line$1, join$2(concat$2([",", line$1]), printed)])),
               shouldPrintComma(options, "all") ? "," : "",
-              line$1,
+              calypsoLine,
               ")"
             ]),
             { shouldBreak: true }
@@ -12831,9 +12889,9 @@ function printArgumentsList(path, options, print) {
   return group$1(
     concat$2([
       "(",
-      indent$2(concat$2([softline$1, join$2(concat$2([",", line$1]), printed)])),
+      indent$2(concat$2([calypsoLine, join$2(concat$2([",", line$1]), printed)])),
       ifBreak$1(shouldPrintComma(options, "all") ? "," : ""),
-      softline$1,
+      calypsoLine,
       ")"
     ]),
     { shouldBreak: printed.some(willBreak$2) }
@@ -12845,6 +12903,8 @@ function printFunctionParams(path, print, options, expandArg) {
   // namedTypes.Function.assert(fun);
   var paramsField = fun.type === "TSFunctionType" ? "parameters" : "params";
   var printed = path.map(print, paramsField);
+  const calypsoSpace = options.calypsoSpacing ? " " : "";
+  const calypsoLine = options.calypsoSpacing ? line$1 : softline$1;
 
   if (fun.defaults) {
     path.each(function(defExprPath) {
@@ -12884,7 +12944,7 @@ function printFunctionParams(path, print, options, expandArg) {
   //   })                    ) => {
   //                         })
   if (expandArg) {
-    return group$1(concat$2(["(", join$2(", ", printed), ")"]));
+    return group$1(concat$2(["( ", join$2(", ", printed), " )"]));
   }
 
   // Single object destructuring should hug
@@ -12903,7 +12963,7 @@ function printFunctionParams(path, print, options, expandArg) {
         fun.params[0].typeAnnotation.type === "ObjectTypeAnnotation")) &&
     !fun.rest
   ) {
-    return concat$2(["(", join$2(", ", printed), ")"]);
+    return concat$2(["(", calypsoSpace, join$2(", ", printed), calypsoSpace, ")"]);
   }
 
   const parent = path.getParentNode();
@@ -12937,11 +12997,11 @@ function printFunctionParams(path, print, options, expandArg) {
 
   return concat$2([
     isFlowShorthandWithOneArg ? "" : "(",
-    indent$2(concat$2([softline$1, join$2(concat$2([",", line$1]), printed)])),
+    indent$2(concat$2([isFlowShorthandWithOneArg ? softline$1 : calypsoLine, join$2(concat$2([",", line$1]), printed)])),
     ifBreak$1(
       canHaveTrailingComma && shouldPrintComma(options, "all") ? "," : ""
     ),
-    softline$1,
+    isFlowShorthandWithOneArg ? softline$1 : calypsoLine,
     isFlowShorthandWithOneArg ? "" : ")"
   ]);
 }
@@ -13211,12 +13271,13 @@ function printClass(path, options, print) {
 function printMemberLookup(path, options, print) {
   const property = path.call(print, "property");
   const n = path.getValue();
+  const calypsoLine = options.calypsoSpacing ? line$1 : softline$1;
 
   return concat$2(
     n.computed
       ? [
           "[",
-          group$1(concat$2([indent$2(concat$2([softline$1, property])), softline$1])),
+          group$1(concat$2([indent$2(concat$2([calypsoLine, property])), calypsoLine])),
           "]"
         ]
       : [".", property]
@@ -15790,8 +15851,6 @@ Object.defineProperty(module, 'exports', {
 });
 });
 
-const style = index$24;
-
 const toString$1 = Object.prototype.toString;
 const toISOString = Date.prototype.toISOString;
 const errorToString = Error.prototype.toString;
@@ -16111,205 +16170,12 @@ function print(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, cu
   return printComplexValue(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName, escapeRegex, colors);
 }
 
-const DEFAULTS = {
-  callToJSON: true,
-  escapeRegex: false,
-  highlight: false,
-  indent: 2,
-  maxDepth: Infinity,
-  min: false,
-  plugins: [],
-  printFunctionName: true,
-  theme: {
-    content: 'reset',
-    prop: 'yellow',
-    tag: 'cyan',
-    value: 'green' } };
-
-
-
-function validateOptions(opts) {
-  Object.keys(opts).forEach(key => {
-    if (!DEFAULTS.hasOwnProperty(key)) {
-      throw new Error('prettyFormat: Invalid option: ' + key);
-    }
-  });
-
-  if (opts.min && opts.indent !== undefined && opts.indent !== 0) {
-    throw new Error('prettyFormat: Cannot run with min option and indent');
-  }
-}
-
-function normalizeOptions$1(opts) {
-  const result = {};
-
-  Object.keys(DEFAULTS).forEach(key =>
-  result[key] = opts.hasOwnProperty(key) ? opts[key] : DEFAULTS[key]);
-
-
-  if (result.min) {
-    result.indent = 0;
-  }
-
-  return result;
-}
-
-function createIndent(indent) {
-  return new Array(indent + 1).join(' ');
-}
-
-function prettyFormat(val, opts) {
-  if (!opts) {
-    opts = DEFAULTS;
-  } else {
-    validateOptions(opts);
-    opts = normalizeOptions$1(opts);
-  }
-
-  const colors = {};
-  Object.keys(opts.theme).forEach(key => {
-    if (opts.highlight) {
-      colors[key] = style[opts.theme[key]];
-    } else {
-      colors[key] = { close: '', open: '' };
-    }
-  });
-
-  let indent;
-  let refs;
-  const prevIndent = '';
-  const currentDepth = 0;
-  const spacing = opts.min ? ' ' : '\n';
-  const edgeSpacing = opts.min ? '' : '\n';
-
-  if (opts && opts.plugins.length) {
-    indent = createIndent(opts.indent);
-    refs = [];
-    const pluginsResult = printPlugin(val, indent, prevIndent, spacing, edgeSpacing, refs, opts.maxDepth, currentDepth, opts.plugins, opts.min, opts.callToJSON, opts.printFunctionName, opts.escapeRegex, colors);
-    if (pluginsResult) {
-      return pluginsResult;
-    }
-  }
-
-  const basicResult = printBasicValue(val, opts.printFunctionName, opts.escapeRegex);
-  if (basicResult) {
-    return basicResult;
-  }
-
-  if (!indent) {
-    indent = createIndent(opts.indent);
-  }
-  if (!refs) {
-    refs = [];
-  }
-  return printComplexValue(val, indent, prevIndent, spacing, edgeSpacing, refs, opts.maxDepth, currentDepth, opts.plugins, opts.min, opts.callToJSON, opts.printFunctionName, opts.escapeRegex, colors);
-}
-
-var index$22 = prettyFormat;
-
 /* eslint-disable no-nested-ternary */
 var arr = [];
 var charCodeCache = [];
 
-var index$30 = function (a, b) {
-	if (a === b) {
-		return 0;
-	}
-
-	var aLen = a.length;
-	var bLen = b.length;
-
-	if (aLen === 0) {
-		return bLen;
-	}
-
-	if (bLen === 0) {
-		return aLen;
-	}
-
-	var bCharCode;
-	var ret;
-	var tmp;
-	var tmp2;
-	var i = 0;
-	var j = 0;
-
-	while (i < aLen) {
-		charCodeCache[i] = a.charCodeAt(i);
-		arr[i] = ++i;
-	}
-
-	while (j < bLen) {
-		bCharCode = b.charCodeAt(j);
-		tmp = j++;
-		ret = j;
-
-		for (i = 0; i < aLen; i++) {
-			tmp2 = bCharCode === charCodeCache[i] ? tmp : tmp + 1;
-			tmp = arr[i];
-			ret = arr[i] = tmp > ret ? tmp2 > ret ? ret + 1 : tmp2 : tmp2 > tmp ? tmp + 1 : tmp2;
-		}
-	}
-
-	return ret;
-};
-
 const chalk$1 = index$6;
 const BULLET = chalk$1.bold('\u25cf');
-const DEPRECATION = `${BULLET} Deprecation Warning`;
-const ERROR$1 = `${BULLET} Validation Error`;
-const WARNING = `${BULLET} Validation Warning`;
-
-const format$3 = value =>
-typeof value === 'function' ?
-value.toString() :
-index$22(value, { min: true });
-
-class ValidationError$1 extends Error {
-
-
-
-  constructor(name, message, comment) {
-    super();
-    comment = comment ? '\n\n' + comment : '\n';
-    this.name = '';
-    this.message = chalk$1.red(chalk$1.bold(name) + ':\n\n' + message + comment);
-    Error.captureStackTrace(this, () => {});
-  }}
-
-
-const logValidationWarning = (
-name,
-message,
-comment) =>
-{
-  comment = comment ? '\n\n' + comment : '\n';
-  console.warn(chalk$1.yellow(chalk$1.bold(name) + ':\n\n' + message + comment));
-};
-
-const createDidYouMeanMessage = (
-unrecognized,
-allowedOptions) =>
-{
-  const leven = index$30;
-  const suggestion = allowedOptions.find(option => {
-    const steps = leven(option, unrecognized);
-    return steps < 3;
-  });
-
-  return suggestion ?
-  `Did you mean ${chalk$1.bold(format$3(suggestion))}?` :
-  '';
-};
-
-var utils$3 = {
-  DEPRECATION,
-  ERROR: ERROR$1,
-  ValidationError: ValidationError$1,
-  WARNING,
-  createDidYouMeanMessage,
-  format: format$3,
-  logValidationWarning };
 
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
@@ -16319,352 +16185,6 @@ var utils$3 = {
  * of patent rights can be found in the PATENTS file in the same directory.
  * 
  */
-
-const asymmetricMatcher = Symbol.for('jest.asymmetricMatcher');
-const SPACE = ' ';
-
-class ArrayContaining extends Array {}
-class ObjectContaining extends Object {}
-
-const printAsymmetricMatcher = (
-val,
-print,
-indent,
-opts,
-colors) =>
-{
-  const stringedValue = val.toString();
-
-  if (stringedValue === 'ArrayContaining') {
-    const array = ArrayContaining.from(val.sample);
-    return opts.spacing === SPACE ?
-    stringedValue + SPACE + print(array) :
-    print(array);
-  }
-
-  if (stringedValue === 'ObjectContaining') {
-    const object = Object.assign(new ObjectContaining(), val.sample);
-    return opts.spacing === SPACE ?
-    stringedValue + SPACE + print(object) :
-    print(object);
-  }
-
-  if (stringedValue === 'StringMatching') {
-    return stringedValue + SPACE + print(val.sample);
-  }
-
-  if (stringedValue === 'StringContaining') {
-    return stringedValue + SPACE + print(val.sample);
-  }
-
-  return val.toAsymmetricMatcher();
-};
-
-var AsymmetricMatcher = {
-  print: printAsymmetricMatcher,
-  test: object => object && object.$$typeof === asymmetricMatcher };
-
-const chalk$2 = index$6;
-const prettyFormat$1 = index$22;
-const AsymmetricMatcherPlugin = AsymmetricMatcher;
-
-const PLUGINS = [AsymmetricMatcherPlugin];
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-const EXPECTED_COLOR = chalk$2.green;
-const EXPECTED_BG = chalk$2.bgGreen;
-const RECEIVED_COLOR = chalk$2.red;
-const RECEIVED_BG = chalk$2.bgRed;
-
-const NUMBERS = [
-'zero',
-'one',
-'two',
-'three',
-'four',
-'five',
-'six',
-'seven',
-'eight',
-'nine',
-'ten',
-'eleven',
-'twelve',
-'thirteen'];
-
-
-// get the type of a value with handling the edge cases like `typeof []`
-// and `typeof null`
-const getType$1 = value => {
-  if (typeof value === 'undefined') {
-    return 'undefined';
-  } else if (value === null) {
-    return 'null';
-  } else if (Array.isArray(value)) {
-    return 'array';
-  } else if (typeof value === 'boolean') {
-    return 'boolean';
-  } else if (typeof value === 'function') {
-    return 'function';
-  } else if (typeof value === 'number') {
-    return 'number';
-  } else if (typeof value === 'string') {
-    return 'string';
-  } else if (typeof value === 'object') {
-    if (value.constructor === RegExp) {
-      return 'regexp';
-    } else if (value.constructor === Map) {
-      return 'map';
-    } else if (value.constructor === Set) {
-      return 'set';
-    }
-    return 'object';
-    // $FlowFixMe https://github.com/facebook/flow/issues/1015
-  } else if (typeof value === 'symbol') {
-    return 'symbol';
-  }
-
-  throw new Error(`value of unknown type: ${value}`);
-};
-
-const stringify = function (object) {let maxDepth = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 10;
-  const MAX_LENGTH = 10000;
-  let result;
-
-  try {
-    result = prettyFormat$1(object, {
-      maxDepth,
-      min: true,
-      plugins: PLUGINS });
-
-  } catch (e) {
-    result = prettyFormat$1(object, {
-      callToJSON: false,
-      maxDepth,
-      min: true,
-      plugins: PLUGINS });
-
-  }
-
-  return result.length >= MAX_LENGTH && maxDepth > 1 ?
-  stringify(object, Math.floor(maxDepth / 2)) :
-  result;
-};
-
-const highlightTrailingWhitespace = (text, bgColor) =>
-text.replace(/\s+$/gm, bgColor('$&'));
-
-const printReceived = object => highlightTrailingWhitespace(
-RECEIVED_COLOR(stringify(object)),
-RECEIVED_BG);
-
-const printExpected = value => highlightTrailingWhitespace(
-EXPECTED_COLOR(stringify(value)),
-EXPECTED_BG);
-
-
-const printWithType = (
-name,
-received,
-print) =>
-{
-  const type = getType$1(received);
-  return (
-    name + ':' + (
-    type !== 'null' && type !== 'undefined' ?
-    '\n  ' + type + ': ' :
-    ' ') +
-    print(received));
-
-};
-
-const ensureNoExpected = (expected, matcherName) => {
-  matcherName || (matcherName = 'This');
-  if (typeof expected !== 'undefined') {
-    throw new Error(
-    matcherHint('[.not]' + matcherName, undefined, '') + '\n\n' +
-    'Matcher does not accept any arguments.\n' +
-    printWithType('Got', expected, printExpected));
-
-  }
-};
-
-const ensureActualIsNumber = (actual, matcherName) => {
-  matcherName || (matcherName = 'This matcher');
-  if (typeof actual !== 'number') {
-    throw new Error(
-    matcherHint('[.not]' + matcherName) + '\n\n' +
-    `Actual value must be a number.\n` +
-    printWithType('Received', actual, printReceived));
-
-  }
-};
-
-const ensureExpectedIsNumber = (expected, matcherName) => {
-  matcherName || (matcherName = 'This matcher');
-  if (typeof expected !== 'number') {
-    throw new Error(
-    matcherHint('[.not]' + matcherName) + '\n\n' +
-    `Expected value must be a number.\n` +
-    printWithType('Got', expected, printExpected));
-
-  }
-};
-
-const ensureNumbers = (actual, expected, matcherName) => {
-  ensureActualIsNumber(actual, matcherName);
-  ensureExpectedIsNumber(expected, matcherName);
-};
-
-const pluralize =
-(word, count) =>
-(NUMBERS[count] || count) + ' ' + word + (count === 1 ? '' : 's');
-
-const matcherHint = function (
-matcherName)
-
-
-
-
-
-
-{let received = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'received';let expected = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'expected';let options = arguments[3];
-  const secondArgument = options && options.secondArgument;
-  const isDirectExpectCall = options && options.isDirectExpectCall;
-  return (
-    chalk$2.dim('expect' + (isDirectExpectCall ? '' : '(')) +
-    RECEIVED_COLOR(received) +
-    chalk$2.dim((isDirectExpectCall ? '' : ')') + matcherName + '(') +
-    EXPECTED_COLOR(expected) + (
-    secondArgument ? `, ${EXPECTED_COLOR(secondArgument)}` : '') +
-    chalk$2.dim(')'));
-
-};
-
-var index$32 = {
-  EXPECTED_BG,
-  EXPECTED_COLOR,
-  RECEIVED_BG,
-  RECEIVED_COLOR,
-  ensureActualIsNumber,
-  ensureExpectedIsNumber,
-  ensureNoExpected,
-  ensureNumbers,
-  getType: getType$1,
-  highlightTrailingWhitespace,
-  matcherHint,
-  pluralize,
-  printExpected,
-  printReceived,
-  printWithType,
-  stringify };
-
-const chalk = index$6;var _require =
-utils$3;const format$2 = _require.format; const ValidationError = _require.ValidationError; const ERROR = _require.ERROR;var _require2 =
-index$32;const getType = _require2.getType;
-
-const errorMessage = (
-option,
-received,
-defaultValue,
-options) =>
-{
-  const message =
-  `  Option ${chalk.bold(`"${option}"`)} must be of type:
-    ${chalk.bold.green(getType(defaultValue))}
-  but instead received:
-    ${chalk.bold.red(getType(received))}
-
-  Example:
-  {
-    ${chalk.bold(`"${option}"`)}: ${chalk.bold(format$2(defaultValue))}
-  }`;
-
-  const comment = options.comment;
-  const name = options.title && options.title.error || ERROR;
-
-  throw new ValidationError(name, message, comment);
-};
-
-var errors = {
-  ValidationError,
-  errorMessage };
-
-var _require$2 =
-
-
-
-utils$3;const logValidationWarning$1 = _require$2.logValidationWarning; const DEPRECATION$2 = _require$2.DEPRECATION;
-
-const deprecationMessage = (message, options) => {
-  const comment = options.comment;
-  const name = options.title && options.title.deprecation || DEPRECATION$2;
-
-  logValidationWarning$1(name, message, comment);
-};
-
-const deprecationWarning$1 = (
-config,
-option,
-deprecatedOptions,
-options) =>
-{
-  if (option in deprecatedOptions) {
-    deprecationMessage(deprecatedOptions[option](config), options);
-
-    return true;
-  }
-
-  return false;
-};
-
-var deprecated = {
-  deprecationWarning: deprecationWarning$1 };
-
-const chalk$3 = index$6;var _require$3 =
-
-
-
-
-
-utils$3;const format$4 = _require$3.format; const logValidationWarning$2 = _require$3.logValidationWarning; const createDidYouMeanMessage$1 = _require$3.createDidYouMeanMessage; const WARNING$2 = _require$3.WARNING;
-
-const unknownOptionWarning$1 = (
-config,
-exampleConfig,
-option,
-options) =>
-{
-  const didYouMean =
-  createDidYouMeanMessage$1(option, Object.keys(exampleConfig));
-  /* eslint-disable max-len */
-  const message =
-  `  Unknown option ${chalk$3.bold(`"${option}"`)} with value ${chalk$3.bold(format$4(config[option]))} was found.` + (
-  didYouMean && ` ${didYouMean}`) +
-  `\n  This is probably a typing mistake. Fixing it will remove this message.`;
-  /* eslint-enable max-len */
-
-  const comment = options.comment;
-  const name = options.title && options.title.warning || WARNING$2;
-
-  logValidationWarning$2(name, message, comment);
-};
-
-var warnings = {
-  unknownOptionWarning: unknownOptionWarning$1 };
 
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
@@ -16676,25 +16196,6 @@ var warnings = {
  * 
  */
 
-const config$1 = {
-  comment: '  A comment',
-  condition: (option, validOption) => true,
-  deprecate: (config, option, deprecatedOptions, options) => false,
-  deprecatedConfig: {
-    key: config => {} },
-
-  error: (option, received, defaultValue, options) => {},
-  exampleConfig: { key: 'value', test: 'case' },
-  title: {
-    deprecation: 'Deprecation Warning',
-    error: 'Validation Error',
-    warning: 'Validation Warning' },
-
-  unknown: (config, option, options) => {} };
-
-
-var exampleConfig$2 = config$1;
-
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *
@@ -16704,132 +16205,15 @@ var exampleConfig$2 = config$1;
  *
  * 
  */
-
-const toString$2 = Object.prototype.toString;
-
-const validationCondition$1 = (
-option,
-validOption) =>
-{
-  return (
-    option === null ||
-    option === undefined ||
-    toString$2.call(option) === toString$2.call(validOption));
-
-};
-
-var condition = validationCondition$1;
-
-var _require$1 =
-
-
-
-deprecated;const deprecationWarning = _require$1.deprecationWarning;var _require2$1 =
-warnings;const unknownOptionWarning = _require2$1.unknownOptionWarning;var _require3 =
-errors;const errorMessage$1 = _require3.errorMessage;
-const exampleConfig$1 = exampleConfig$2;
-const validationCondition = condition;var _require4 =
-utils$3;const ERROR$2 = _require4.ERROR; const DEPRECATION$1 = _require4.DEPRECATION; const WARNING$1 = _require4.WARNING;
-
-var defaultConfig$1 = {
-  comment: '',
-  condition: validationCondition,
-  deprecate: deprecationWarning,
-  deprecatedConfig: {},
-  error: errorMessage$1,
-  exampleConfig: exampleConfig$1,
-  title: {
-    deprecation: DEPRECATION$1,
-    error: ERROR$2,
-    warning: WARNING$1 },
-
-  unknown: unknownOptionWarning };
-
-const defaultConfig = defaultConfig$1;
-
-const _validate = (config, options) => {
-  let hasDeprecationWarnings = false;
-
-  for (const key in config) {
-    if (
-    options.deprecatedConfig &&
-    key in options.deprecatedConfig &&
-    typeof options.deprecate === 'function')
-    {
-      const isDeprecatedKey = options.deprecate(
-      config,
-      key,
-      options.deprecatedConfig,
-      options);
-
-
-      hasDeprecationWarnings = hasDeprecationWarnings || isDeprecatedKey;
-    } else if (hasOwnProperty.call(options.exampleConfig, key)) {
-      if (
-      typeof options.condition === 'function' &&
-      typeof options.error === 'function' &&
-      !options.condition(config[key], options.exampleConfig[key]))
-      {
-        options.error(key, config[key], options.exampleConfig[key], options);
-      }
-    } else {
-      options.unknown &&
-      options.unknown(config, options.exampleConfig, key, options);
-    }
-  }
-
-  return { hasDeprecationWarnings };
-};
-
-const validate$1 = (config, options) => {
-  _validate(options, defaultConfig); // validate against jest-validate config
-
-  const defaultedOptions = Object.assign(
-  {},
-  defaultConfig,
-  options,
-  { title: Object.assign({}, defaultConfig.title, options.title) });var _validate2 =
-
-
-  _validate(config, defaultedOptions);const hasDeprecationWarnings = _validate2.hasDeprecationWarnings;
-
-  return {
-    hasDeprecationWarnings,
-    isValid: true };
-
-};
-
-var validate_1 = validate$1;
-
-var index$20 = {
-  ValidationError: errors.ValidationError,
-  createDidYouMeanMessage: utils$3.createDidYouMeanMessage,
-  format: utils$3.format,
-  logValidationWarning: utils$3.logValidationWarning,
-  validate: validate_1 };
-
-const deprecated$2 = {
-  useFlowParser: config =>
-    `  The ${'"useFlowParser"'} option is deprecated. Use ${'"parser"'} instead.
-
-  Prettier now treats your configuration as:
-  {
-    ${'"parser"'}: ${config.useFlowParser ? '"flow"' : '"babylon"'}
-  }`
-};
-
-var deprecated_1 = deprecated$2;
-
-var validate = index$20.validate;
-var deprecatedConfig = deprecated_1;
 
 var defaults = {
-  useTabs: false,
+  useTabs: true,
   tabWidth: 2,
-  printWidth: 80,
-  singleQuote: false,
-  trailingComma: "none",
+  printWidth: 100,
+  singleQuote: true,
+  trailingComma: "all",
   bracketSpacing: true,
+  calypsoSpacing: true,
   jsxBracketSameLine: false,
   parser: "babylon",
   semi: true
@@ -16843,6 +16227,7 @@ var exampleConfig = Object.assign({}, defaults, {
 
 // Copy options and fill in default values.
 function normalize(options) {
+  /*
   const normalized = Object.assign({}, options || {});
 
   if (typeof normalized.trailingComma === "boolean") {
@@ -16871,6 +16256,10 @@ function normalize(options) {
   });
 
   return normalized;
+  */
+
+ // we have strong opinions on calypso
+ return Object.assign( {}, defaults );
 }
 
 var options = { normalize };
@@ -30337,6 +29726,7 @@ function printDoc(doc) {
 
     return (
       (doc.break ? "wrappedGroup" : "group") +
+      (doc.addedLine ? "WithTrailingLine" : "") +
       "(" +
       printDoc(doc.contents) +
       ")"

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -46,6 +46,7 @@ function group(contents, opts) {
     type: "group",
     contents: contents,
     break: !!opts.shouldBreak,
+    addedLine: !!opts.addedLine,
     expandedStates: opts.expandedStates
   };
 }

--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -95,6 +95,7 @@ function printDoc(doc) {
 
     return (
       (doc.break ? "wrappedGroup" : "group") +
+      (doc.addedLine ? "WithTrailingLine" : "") +
       "(" +
       printDoc(doc.contents) +
       ")"

--- a/src/options.js
+++ b/src/options.js
@@ -10,6 +10,7 @@ var defaults = {
   singleQuote: true,
   trailingComma: "all",
   bracketSpacing: true,
+  calypsoSpacing: true,
   jsxBracketSameLine: false,
   parser: "babylon",
   semi: true

--- a/src/printer.js
+++ b/src/printer.js
@@ -114,13 +114,13 @@ function genericPrint(path, options, printPath, args) {
   }
 
   if (needsParens) {
-    parts.unshift("( ");
+    parts.unshift("(", " ");
   }
 
   parts.push(linesWithoutParens);
 
   if (needsParens) {
-    parts.push(" )");
+    parts.push(" ", ")");
   }
 
   return concat(parts);
@@ -182,7 +182,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "ExpressionStatement":
       return concat([path.call(print, "expression"), semi]); // Babel extension.
     case "ParenthesizedExpression":
-      return concat(["( ", path.call(print, "expression"), " )"]);
+      return concat(["(", " ", path.call(print, "expression"), " ", ")"]);
     case "AssignmentExpression":
       return printAssignment(
         n.left,
@@ -661,7 +661,7 @@ function genericPrintNoParens(path, options, print, args) {
         return concat([
           path.call(print, "callee"),
           path.call(print, "typeParameters"),
-          concat(["( ", join(", ", path.map(print, "arguments")), " )"])
+          concat(["(", " ", join(", ", path.map(print, "arguments")), " ", ")"])
         ]);
       }
 
@@ -787,7 +787,7 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push(path.call(print, "value"));
       } else {
         if (n.computed) {
-          parts.push("[ ", path.call(print, "key"), " ]");
+          parts.push("[", " ", path.call(print, "key"), " ", "]");
         } else {
           parts.push(printPropertyKey(path, options, print));
         }
@@ -841,10 +841,10 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push(
           group(
             concat([
-              "[ ",
+              "[",
               indent(
                 concat([
-                  softline,
+                  line,
                   printArrayItems(path, options, "elements", print)
                 ])
               ),
@@ -861,8 +861,7 @@ function genericPrintNoParens(path, options, print, args) {
                 options,
                 /* sameIndent */ true
               ),
-              " ",
-              softline,
+              line,
               "]"
             ])
           )
@@ -908,8 +907,10 @@ function genericPrintNoParens(path, options, print, args) {
       return nodeStr(n, options);
     case "UnaryExpression":
       parts.push(n.operator);
-      if ( n.argument && n.argument.type !== "UnaryExpression" && ( n.operator !== '+' && n.operator !== '-') ) {
-        parts.push(' ');
+
+      if (/[a-z]$/.test(n.operator)) parts.push(" ");
+      if (n.operator === '!' && !(n.argument && n.argument.type === "UnaryExpression" && n.argument.operator === '!')) {
+        parts.push(" ");
       }
 
       parts.push(path.call(print, "argument"));
@@ -991,8 +992,10 @@ function genericPrintNoParens(path, options, print, args) {
       );
     case "WithStatement":
       return concat([
-        "with ( ",
+        "with (",
+        " ",
         path.call(print, "object"),
+        " ",
         ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
@@ -1000,12 +1003,11 @@ function genericPrintNoParens(path, options, print, args) {
       const con = adjustClause(n.consequent, path.call(print, "consequent"));
       const opening = group(
         concat([
-          "if ( ",
+          "if (",
           group(
             concat([
-              indent(concat([softline, path.call(print, "test")])),
-							" ", // hack to support only putting the extra space for closing parens that are not immediately after newlines
-              softline
+              indent(concat([line, path.call(print, "test")])),
+              line
             ])
           ),
           ")",
@@ -1053,12 +1055,12 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat([
         printedComments,
-        "for ( ",
+        "for (",
         group(
           concat([
             indent(
               concat([
-                softline,
+                line,
                 path.call(print, "init"),
                 ";",
                 line,
@@ -1068,33 +1070,35 @@ function genericPrintNoParens(path, options, print, args) {
                 path.call(print, "update")
               ])
             ),
-            softline
+            line
           ])
         ),
-        " )",
+        ")",
         body
       ]);
     }
     case "WhileStatement":
       return concat([
-        "while ( ",
+        "while (",
         group(
           concat([
-            indent(concat([softline, path.call(print, "test")])),
-            softline
+            indent(concat([line, path.call(print, "test")])),
+            line
           ])
         ),
-        " )",
+        ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
     case "ForInStatement":
       // Note: esprima can't actually parse "for each (".
       return concat([
-        n.each ? "for each ( " : "for ( ",
+        n.each ? "for each (" : "for (",
+        " ",
         path.call(print, "left"),
         " in ",
         path.call(print, "right"),
-        " )",
+        " ",
+        ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
 
@@ -1108,11 +1112,13 @@ function genericPrintNoParens(path, options, print, args) {
       return concat([
         "for",
         isAwait ? " await" : "",
-        " ( ",
+        " (",
+        " ",
         path.call(print, "left"),
         " of ",
         path.call(print, "right"),
-        " )",
+        " ",
+        ")",
         adjustClause(n.body, path.call(print, "body"))
       ]);
 
@@ -1128,7 +1134,7 @@ function genericPrintNoParens(path, options, print, args) {
       }
       parts.push("while");
 
-      parts.push(" ( ", path.call(print, "test"), " )", semi);
+      parts.push(" (", " ", path.call(print, "test"), " ", ")", semi);
 
       return concat(parts);
     case "DoExpression":
@@ -1176,13 +1182,13 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat(parts);
     case "CatchClause":
-      parts.push("catch ( ", path.call(print, "param"));
+      parts.push("catch (", " ", path.call(print, "param"));
 
       if (n.guard)
         // Note: esprima does not recognize conditional catch clauses.
         parts.push(" if ", path.call(print, "guard"));
 
-      parts.push(" ) ", path.call(print, "body"));
+      parts.push(" ", ") ", path.call(print, "body"));
 
       return concat(parts);
     case "ThrowStatement":
@@ -1190,9 +1196,11 @@ function genericPrintNoParens(path, options, print, args) {
     // Note: ignoring n.lexical because it has no printing consequences.
     case "SwitchStatement":
       return concat([
-        "switch ( ",
+        "switch (",
+        " ",
         path.call(print, "discriminant"),
-        " ) {",
+        " ",
+        ") {",
         n.cases.length > 0
           ? indent(concat([hardline, join(hardline, path.map(print, "cases"))]))
           : "",
@@ -1249,10 +1257,10 @@ function genericPrintNoParens(path, options, print, args) {
           (n.value.type === "StringLiteral" || n.value.type === "Literal") &&
           typeof n.value.value === "string"
         ) {
-          const value = n.value.extra ? n.value.extra.raw : n.value.value;
+          const value = n.value.extra ? n.value.extra.raw : n.value.raw;
           res =
             '"' +
-            value.slice(1, value.length-1).replace(/"/g, "&quot;") +
+            value.slice(1, value.length - 1).replace(/"/g, "&quot;") +
             '"';
         } else {
           res = path.call(print, "value");
@@ -1274,7 +1282,7 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "property")
       ]);
     case "JSXSpreadAttribute":
-      return concat(["{ ...", path.call(print, "argument"), " }"]);
+      return concat(["{", " ", "...", path.call(print, "argument"), " ", "}"]);
     case "JSXExpressionContainer": {
       const parent = path.getParentNode(0);
 
@@ -1293,16 +1301,15 @@ function genericPrintNoParens(path, options, print, args) {
 
       if (shouldInline) {
         return group(
-          concat(["{ ", path.call(print, "expression"), lineSuffixBoundary, " }"])
+          concat(["{", " ", path.call(print, "expression"), lineSuffixBoundary, " ", "}"])
         );
       }
 
       return group(
         concat([
-          "{ ",
-          indent(concat([softline, path.call(print, "expression")])),
-          " ",
-          softline,
+          "{",
+          indent(concat([line, path.call(print, "expression")])),
+          line,
           lineSuffixBoundary,
           "}"
         ])
@@ -1463,10 +1470,12 @@ function genericPrintNoParens(path, options, print, args) {
 
         if (i < expressions.length) {
           parts.push(
-            "${ ",
+            "${",
+            " ",
             removeLines(expressions[i]),
             lineSuffixBoundary,
-            " }"
+            " ",
+            "}"
           );
         }
       }, "quasis");
@@ -2203,31 +2212,35 @@ function printArgumentsList(path, options, print) {
       printed.some(willBreak) ? breakParent : "",
       conditionalGroup(
         [
-          concat(["( ", join(concat([", "]), printedExpanded), " )"]),
+          concat(["(", " ", join(concat([", "]), printedExpanded), " ", ")"]),
           shouldGroupFirst
             ? concat([
-                "( ",
+                "(",
+                " ",
                 group(printedExpanded[0], { shouldBreak: true }),
                 printed.length > 1 ? ", " : "",
                 join(concat([",", line]), printed.slice(1)),
-                " )"
+                " ",
+                ")"
               ])
             : concat([
-                "( ",
+                "(",
+                " ",
                 join(concat([",", line]), printed.slice(0, -1)),
                 printed.length > 1 ? ", " : "",
                 group(util.getLast(printedExpanded), {
-                  shouldBreak: false,
+                  shouldBreak: true
                 }),
-                " )"
+                " ",
+                ")"
               ]),
           group(
             concat([
-              "( ",
+              "(",
               indent(concat([line, join(concat([",", line]), printed)])),
               shouldPrintComma(options, "all") ? "," : "",
               line,
-              ")" // do not have extra space after a line!
+              ")"
             ]),
             { shouldBreak: true }
           )
@@ -2239,11 +2252,10 @@ function printArgumentsList(path, options, print) {
 
   return group(
     concat([
-      "( ",
-      indent(concat([softline, join(concat([",", line]), printed)])),
+      "(",
+      indent(concat([line, join(concat([",", line]), printed)])),
       ifBreak(shouldPrintComma(options, "all") ? "," : ""),
-      " ", // hack to add extra whitespace as before parens but not for newline
-      softline,
+      line,
       ")"
     ]),
     { shouldBreak: printed.some(willBreak) }
@@ -2313,7 +2325,7 @@ function printFunctionParams(path, print, options, expandArg) {
         fun.params[0].typeAnnotation.type === "ObjectTypeAnnotation")) &&
     !fun.rest
   ) {
-    return concat(["( ", join(", ", printed), " )"]);
+    return concat(["(", " ", join(", ", printed), " ", ")"]);
   }
 
   const parent = path.getParentNode();
@@ -2346,13 +2358,13 @@ function printFunctionParams(path, print, options, expandArg) {
     !fun.rest;
 
   return concat([
-    isFlowShorthandWithOneArg ? "" : "( ",
-    indent(concat([softline, join(concat([",", line]), printed)])),
+    isFlowShorthandWithOneArg ? "" : "(",
+    indent(concat([isFlowShorthandWithOneArg ? softline : line, join(concat([",", line]), printed)])),
     ifBreak(
       canHaveTrailingComma && shouldPrintComma(options, "all") ? "," : ""
     ),
-    softline,
-    isFlowShorthandWithOneArg ? "" : " )"
+    isFlowShorthandWithOneArg ? softline : line,
+    isFlowShorthandWithOneArg ? "" : ")"
   ]);
 }
 
@@ -2633,9 +2645,9 @@ function printMemberLookup(path, options, print) {
   return concat(
     n.computed
       ? [
-          "[ ",
-          group(concat([indent(concat([softline, property])), softline])),
-          " ]"
+          "[",
+          group(concat([indent(concat([line, property])), line])),
+          "]"
         ]
       : [".", property]
   );


### PR DESCRIPTION
- for parens that don't line-break, turn the added spaces into separate atoms. In future, they will be added conditionally when an option is enabled -- this change makes it easier.
- for parens that can line-break, play with `softline`/`line` instead of adding spaces -- that leads to more reliable formatting without bugs
- fine-tune the unary expression spacing to make it conform better to how `space-unary-ops` is configured in `eslint-config-wpcalypso`

@samouri Would you mind trying out this branch and checking if the results are better? I'm only aware about one bug:
```js
map( a =>
  a(),
 ); // extra space
```
This case is quite tough, I hope to solve it in the next day or two.

My dream here is to introduce a `calypsoSpacing` option for prettier, and make the fork support both the enabled and disabled state -- with the enabled state being the hardcoded default for us.

That would make a merge into the official version at least theoretically possible.

To test, check that the following rules as defined in `eslint-config-wpcalypso` are always happy:
- `computed-property-spacing`
- `space-in-parens`
- `space-unary-ops`
- `jsx-curly-spacing`
- `template-curly-spacing`
- `object-curly-spacing`
