### PR TITLE
Fix parens around LogicalExpression wrapped inside UnaryExpression

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -297,6 +297,14 @@ FastPath.prototype.needsParens = function(options) {
         case "AwaitExpression":
         case "TSAsExpression":
         case "TSNonNullExpression":
+          // Logical and Binary expressions already got their parens if parent is UnaryExpression
+          if (
+            parent.type === "UnaryExpression" &&
+            (node.type === "LogicalExpression" ||
+              node.type === "BinaryExpression")
+          ) {
+            return false;
+          }
           return true;
 
         case "MemberExpression":

--- a/src/printer.js
+++ b/src/printer.js
@@ -303,7 +303,12 @@ function genericPrintNoParens(path, options, print, args) {
 
       if (parent.type === "UnaryExpression") {
         return group(
-          concat([indent(concat([softline, concat(parts)])), softline])
+          concat([
+            "(",
+            indent(concat([parenLine, concat(parts)])),
+            parenLine,
+            ")"
+          ])
         );
       }
 

--- a/website/static/lib/index.js
+++ b/website/static/lib/index.js
@@ -1605,6 +1605,10 @@ FastPath$1.prototype.needsParens = function (options) {
         case "AwaitExpression":
         case "TSAsExpression":
         case "TSNonNullExpression":
+          // Logical and Binary expressions already got their parens if parent is UnaryExpression
+          if (parent.type === "UnaryExpression" && (node.type === "LogicalExpression" || node.type === "BinaryExpression")) {
+            return false;
+          }
           return true;
 
         case "MemberExpression":
@@ -4194,7 +4198,7 @@ function genericPrintNoParens(path$$1, options, print, args) {
         }
 
         if (parent.type === "UnaryExpression") {
-          return group$1(concat$2([indent$2(concat$2([softline$1, concat$2(_parts2)])), softline$1]));
+          return group$1(concat$2(["(", indent$2(concat$2([parenLine, concat$2(_parts2)])), parenLine, ")"]));
         }
 
         // Avoid indenting sub-expressions in assignment/return/etc statements.


### PR DESCRIPTION
Before:
```js
! (
  a || b
 )
```
After:
```js
! (
  a || b
)
```
Reported in https://github.com/Automattic/wp-calypso/pull/15959

Fixed by inserting the parens directly when formatting a Binary or LogicalExpression instead
of relying on `genericPrint` inserting them depending on result of `path.needParens`.

All unit tests continue to pass (including the Flow and Typescript ones).



