### PR TITLE
Options: Trailing Commas Compatibility

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -11,7 +11,7 @@ const defaults = {
   tabWidth: 2,
   printWidth: 100,
   singleQuote: true,
-  trailingComma: "all",
+  trailingComma: "es5",
   bracketSpacing: true,
   parenSpacing: true,
   jsxBracketSameLine: false,


### PR DESCRIPTION
We should use `es5` instead of `all` for our trailing comma option.  We still have many scripts that get run via `node` without compiling and it would be nice to be able to use this project to format them.

Inspired from [here](https://github.com/Automattic/wp-calypso/pull/16394#discussion_r128932887).

The argument against this would be: trailing commas are great and make our diffs easier to read. Lets just not use prettier on things that need to be es5 compat. I don't think this argument holds any weight against the argument for it.