### PR TITLE
if not present, prepend @format docblock

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -146,6 +146,7 @@ const options = {
   tabWidth: getIntOption("tab-width"),
   bracketSpacing: argv["bracket-spacing"],
   parenSpacing: argv["paren-spacing"],
+  prependFormatComment: argv["prepend-format-comment"],
   singleQuote: argv["single-quote"],
   jsxBracketSameLine: argv["jsx-bracket-same-line"],
   filepath: argv["stdin-filepath"],

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const printDocToString = require("./src/doc-printer").printDocToString;
 const normalizeOptions = require("./src/options").normalize;
 const parser = require("./src/parser");
 const printDocToDebug = require("./src/doc-debug").printDocToDebug;
+const prependFormatIfAbsent = require("./src/calypso-utils")
+  .prependFormatIfAbsent;
 
 function guessLineEnding(text) {
   const index = text.indexOf("\n");
@@ -56,6 +58,14 @@ function ensureAllCommentsPrinted(astComments) {
 
 function formatWithCursor(text, opts, addAlignmentSize) {
   text = stripBom(text);
+  // @todo: fix/verify that cursor offset is still correct even after @format is prepended
+  if (
+    opts.prependFormatComment &&
+    opts.rangeStart === 0 &&
+    opts.rangeEnd === Infinity
+  ) {
+    text = prependFormatIfAbsent(text);
+  }
   addAlignmentSize = addAlignmentSize || 0;
 
   const ast = parser.parse(text, opts);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "get-stream": "3.0.0",
     "globby": "^6.1.0",
     "graphql": "0.10.1",
+    "jest-docblock": "^20.0.3",
     "jest-validate": "20.0.3",
     "json-to-ast": "2.0.0-alpha1.2",
     "minimist": "1.2.0",

--- a/src/calypso-utils.js
+++ b/src/calypso-utils.js
@@ -1,0 +1,32 @@
+"use strict";
+const docblock = require('jest-docblock');
+
+/**
+ * Returns true if the given text contains @format.
+ * within its first docblock. False otherwise.
+ *
+ * @param {String} text text to scan for the format keyword within the first docblock
+ */
+const shouldFormat = text => {
+  const directives = docblock.parse(text);
+  return Object.keys(directives).indexOf('format') >= 0;
+};
+
+/**
+ * Given the src code for a file:
+ *   if the first docblock in the file contains @format, do nothing
+ *   else return the text but with @format in a docblock prepended
+ * 
+ * @param String text to prepend "/** @format *\/" to if it doesn't exist already
+ */
+const prependFormatIfAbsent = text => {
+  if (shouldFormat(text)) {
+    return text;
+  }
+  return `/** @format */\n${text}`;
+};
+
+module.exports = {
+  shouldFormat,
+  prependFormatIfAbsent
+};

--- a/src/options.js
+++ b/src/options.js
@@ -7,6 +7,21 @@ const defaults = {
   cursorOffset: -1,
   rangeStart: 0,
   rangeEnd: Infinity,
+  useTabs: false,
+  tabWidth: 2,
+  printWidth: 80,
+  singleQuote: false,
+  trailingComma: "none",
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  parser: "babylon",
+  semi: true
+}; 
+
+const calypsoDefaults = {
+  cursorOffset: -1,
+  rangeStart: 0,
+  rangeEnd: Infinity,
   useTabs: true,
   tabWidth: 2,
   printWidth: 100,
@@ -29,8 +44,9 @@ const exampleConfig = Object.assign({}, defaults, {
 // Copy options and fill in default values.
 function normalize(options) {
   // Calypso fork ignores all options and always uses the defaults. This is an escape hatch.
+  // comment out this block when running tests
   if (!options.unlockOptions) {
-    return Object.assign({}, defaults);
+    return Object.assign({}, calypsoDefaults);
   }
 
   const normalized = Object.assign({}, options || {});

--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,7 @@ const defaults = {
   trailingComma: "es5",
   bracketSpacing: true,
   parenSpacing: true,
+  prependFormatComment: true,
   jsxBracketSameLine: false,
   parser: "babylon",
   semi: true

--- a/tests/calypso/jsfmt.spec.js
+++ b/tests/calypso/jsfmt.spec.js
@@ -1,0 +1,45 @@
+const calypsoUtils = require("../../src/calypso-utils");
+const shouldFormat = calypsoUtils.shouldFormat;
+const prependFormatIfAbsent = calypsoUtils.prependFormatIfAbsent;
+
+const shouldFormatExamples = [
+  `/**@format*/`,
+  `/** @format*/`,
+  `/** @format */`,
+  `/** @format */ `,
+  `/** 
+  * @format 
+  * @distraction
+  */`,
+  `/**
+   * @format
+   */`
+];
+
+const shouldNotFormatExamples = [
+  "",
+  "/* @format */",
+  "/** first docblock */ /** @format */"
+];
+
+// [ before, after ]
+const prependFormatIfAbsentExamples = [
+  ["", "/** @format */\n"],
+  ["heres some text", "/** @format */\nheres some text"]
+];
+
+test("should format examples", () => {
+  shouldFormatExamples.forEach(text => expect(shouldFormat(text)).toBe(true));
+});
+
+test("should not format examples", () => {
+  shouldNotFormatExamples.forEach(text =>
+    expect(shouldFormat(text)).toBe(false)
+  );
+});
+
+test("prependFormatIfNecessary", () => {
+  prependFormatIfAbsentExamples.forEach(testCase =>
+    expect(prependFormatIfAbsent(testCase[0])).toEqual(testCase[1])
+  );
+});


### PR DESCRIPTION

Inspired by the [adoption at Facebook](https://github.com/prettier/prettier/releases/tag/1.3.0): mark every prettified file with `/** @format */`.  

Works in tandem with: https://github.com/Automattic/wp-calypso/pull/16394

Note: the thing I don't like about this is its currently breaking every test because it adds the docblock to all of them...
