### PR TITLE
Restore compatibility with eslint-plugin-prettier

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -45,7 +45,7 @@ const exampleConfig = Object.assign({}, defaults, {
 function normalize(options) {
   // Calypso fork ignores all options and always uses the defaults. This is an escape hatch.
   // comment out this block when running tests
-  if (!options.unlockOptions) {
+  if (!typeof options === 'object' || !options.unlockOptions) {
     return Object.assign({}, calypsoDefaults);
   }
 


### PR DESCRIPTION
It looks like `normalize` is  sometimes called without any options. This change handles this edge case.