### PR TITLE
Combine pragmas instead of prepend

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const normalizeOptions = require("./src/options").normalize;
 const parser = require("./src/parser");
 const printDocToDebug = require("./src/doc-debug").printDocToDebug;
 const config = require("./src/resolve-config");
-const prependFormatIfAbsent = require("./src/calypso-utils").prependFormatIfAbsent;
+const insertPragma = require("./src/calypso-utils").insertPragma;
 
 function guessLineEnding(text) {
   const index = text.indexOf("\n");
@@ -64,7 +64,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     opts.rangeStart === 0 &&
     opts.rangeEnd === Infinity
   ) {
-    text = prependFormatIfAbsent(text);
+    text = insertPragma(text);
   }
   addAlignmentSize = addAlignmentSize || 0;
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const normalizeOptions = require("./src/options").normalize;
 const parser = require("./src/parser");
 const printDocToDebug = require("./src/doc-debug").printDocToDebug;
 const config = require("./src/resolve-config");
-const insertPragma = require("./src/calypso-utils").insertPragma;
+const withPragma = require("./src/calypso-utils").withPragma;
 
 function guessLineEnding(text) {
   const index = text.indexOf("\n");
@@ -64,7 +64,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     opts.rangeStart === 0 &&
     opts.rangeEnd === Infinity
   ) {
-    text = insertPragma(text);
+    text = withPragma(text);
   }
   addAlignmentSize = addAlignmentSize || 0;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "globby": "^6.1.0",
     "graphql": "0.10.1",
     "ignore": "^3.3.3",
-    "jest-docblock": "^20.0.3",
+    "jest-docblock": "^21.3.0-alpha.eff7a1cf",
     "jest-validate": "20.0.3",
     "minimatch": "3.0.4",
     "minimist": "1.2.0",

--- a/src/calypso-utils.js
+++ b/src/calypso-utils.js
@@ -7,10 +7,7 @@ const docblock = require("jest-docblock");
  *
  * @param {String} text text to scan for the format keyword within the first docblock
  */
-const shouldFormat = text => {
-  const directives = docblock.parse(text);
-  return Object.keys(directives).indexOf("format") >= 0;
-};
+const shouldFormat = text => "format" in docblock.parse(text);
 
 /**
  * Given the src code for a file:
@@ -24,7 +21,7 @@ const withPragma = text => {
     return text;
   }
   const parsedDocblock = docblock.parseWithComments(docblock.extract(text));
-  const pragmas = Object.assign({}, { format: "" }, parsedDocblock.pragmas);
+  const pragmas = Object.assign({ format: "" }, parsedDocblock.pragmas);
   const newDocblock = docblock.print({
     pragmas,
     comments: parsedDocblock.comments

--- a/src/calypso-utils.js
+++ b/src/calypso-utils.js
@@ -19,7 +19,7 @@ const shouldFormat = text => {
  * 
  * @param String test to ensure has an @format marker in the top docblock
  */
-const insertPragma = text => {
+const withPragma = text => {
   if (shouldFormat(text)) {
     return text;
   }
@@ -34,5 +34,5 @@ const insertPragma = text => {
 
 module.exports = {
   shouldFormat,
-  insertPragma
+  withPragma
 };

--- a/src/calypso-utils.js
+++ b/src/calypso-utils.js
@@ -1,5 +1,5 @@
 "use strict";
-const docblock = require('jest-docblock');
+const docblock = require("jest-docblock");
 
 /**
  * Returns true if the given text contains @format.
@@ -9,24 +9,30 @@ const docblock = require('jest-docblock');
  */
 const shouldFormat = text => {
   const directives = docblock.parse(text);
-  return Object.keys(directives).indexOf('format') >= 0;
+  return Object.keys(directives).indexOf("format") >= 0;
 };
 
 /**
  * Given the src code for a file:
  *   if the first docblock in the file contains @format, do nothing
- *   else return the text but with @format in a docblock prepended
+ *   else return the text but with @format inserted to the first docblock (or a new one generated)
  * 
- * @param String text to prepend "/** @format *\/" to if it doesn't exist already
+ * @param String test to ensure has an @format marker in the top docblock
  */
-const prependFormatIfAbsent = text => {
+const insertPragma = text => {
   if (shouldFormat(text)) {
     return text;
   }
-  return `/** @format */\n${text}`;
+  const parsedDocblock = docblock.parseWithComments(docblock.extract(text));
+  const pragmas = Object.assign({}, { format: "" }, parsedDocblock.pragmas);
+  const newDocblock = docblock.print({
+    pragmas,
+    comments: parsedDocblock.comments
+  });
+  return `${newDocblock}\n${docblock.strip(text)}`;
 };
 
 module.exports = {
   shouldFormat,
-  prependFormatIfAbsent
+  insertPragma
 };


### PR DESCRIPTION
If there is already a top docblock, then just add the pragma to it as opposed to inserting a new top docblock.

This ensures compatibility with other software (jest for now) that also utilizes pragma functionality.
Code copied from: https://github.com/prettier/prettier/pull/2865
Will be used/tested in: https://github.com/Automattic/wp-calypso/pull/18453