### PR TITLE
Fix #25: transposed paren space

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -940,7 +940,7 @@ function printPathNoParens(path, options, print, args) {
                   line,
                   shouldAddParens ? ifBreak("", concat(["(", parenSpace])) : "",
                   body,
-                  shouldAddParens ? ifBreak("", concat([")", parenSpace])) : "",
+                  shouldAddParens ? ifBreak("", concat([parenSpace, ")"])) : "",
                 ])
               ),
               shouldAddLine

--- a/tests/paren_space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/paren_space/__snapshots__/jsfmt.spec.js.snap
@@ -722,6 +722,16 @@ printWidth: 80
 =====================================input======================================
 a => a ? () => { a } : () => { a }
 
+const devOnly = (block) => (!!__DEV__?block:null);
+
+f(result => (result ? result : candidate), 'foobar');
+
+const obj = {
+  foo: 'foo',
+  bar: 'bar',
+  text: () => (typeof text === 'function' ? text() : text),
+};
+
 =====================================output=====================================
 ( a ) =>
   a
@@ -731,6 +741,16 @@ a => a ? () => { a } : () => { a }
     : () => {
         a;
       };
+
+const devOnly = ( block ) => ( !! __DEV__ ? block : null );
+
+f( ( result ) => ( result ? result : candidate ), "foobar" );
+
+const obj = {
+  foo: "foo",
+  bar: "bar",
+  text: () => ( typeof text === "function" ? text() : text ),
+};
 
 ================================================================================
 `;

--- a/tests/paren_space/ternaries.js
+++ b/tests/paren_space/ternaries.js
@@ -1,1 +1,11 @@
 a => a ? () => { a } : () => { a }
+
+const devOnly = (block) => (!!__DEV__?block:null);
+
+f(result => (result ? result : candidate), 'foobar');
+
+const obj = {
+  foo: 'foo',
+  bar: 'bar',
+  text: () => (typeof text === 'function' ? text() : text),
+};


### PR DESCRIPTION
Fixes #25

Fixes transposed paren space reported in https://github.com/WordPress/gutenberg/pull/22610#issuecomment-634227551

Add tests for this case.