### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/bundler-friendly.yml
+++ b/.github/workflows/bundler-friendly.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn build
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn build
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
## Description

v3 is being deprecated in Dec 2024

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Checklist

- n/a I’ve added tests to confirm my change works.
- n/a (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- n/a (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
